### PR TITLE
Prevent undefined cache object access from api

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = function(api) {
-  api.cache(true);
+  if(api && api.cache) api.cache(true);
   return {
     presets: ['babel-preset-expo'],
   };


### PR DESCRIPTION
Fix related issue mentioned at https://github.com/5up-okamura/react-native-draggable-gridview/issues/3
